### PR TITLE
Fix <img> issue on posts list at "/blog"

### DIFF
--- a/src/lib/components/PostCard.svelte
+++ b/src/lib/components/PostCard.svelte
@@ -4,23 +4,25 @@
 	export let date: string;
 	export let authorName: string;
 	export let authorImage: string;
-	export let mainImage: string;
+	// export let mainImage: string;
 	export let topic: string;
 	export let summary: string;
 </script>
 
 <div class="flex w-full flex-col bg-nuv-card-background shadow-nuv-card-box-shadow mb-[24px]">
-	<img src={mainImage} alt={title} class="w-full" />
+	<!-- <img src={mainImage} alt={title} class="w-full" /> -->
 	<div class="flex flex-col p-4">
 		<span class="uppercase font-semibold text-[14px] leading-[16px] text-nuv-orange">
 			{topic}
 		</span>
-		<span class="text-nuv-blue text-[20px] leading-[23px] font-medium mt-[13px]">
-			{title}
-		</span>
+		<a href={'/blog' + `/${slug}`}>
+			<span class="text-nuv-blue text-[20px] leading-[23px] font-medium mt-[13px]">
+				{title}
+			</span>
+		</a>
 		<span class="text-[14px] leading-[16px] font-normal mt-[10px]">
 			{summary}
-			<br /><br /><a href={'/blog' + `/${slug}`} class='text-nuv-orange'>Read more...</a>
+			<br /><br /><a href={'/blog' + `/${slug}`} class="text-nuv-orange">Read more...</a>
 		</span>
 		<div class="mt-[30px] flex">
 			<img src={authorImage} alt={authorName} class="w-[32px] h-[32px] rounded-[16px]" />

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -10,12 +10,10 @@
 
 	export let data: { posts: [any] };
 
-	const getImages = async (post: any) => {
-		return Promise.all([
-			import('./../../content/blog/' + `${post.slug}/${post.image}?url`),
-			autorsImagesFiles[post.author] || autorsImagesFiles['unknown']
-		]).then(([postImageFile, authorImageFile]) => [postImageFile.default, authorImageFile.default]);
-	};
+	const getImages = async (post: any) =>
+		(autorsImagesFiles[post.author] || autorsImagesFiles['unknown']).then(
+			(authorImageFile) => authorImageFile.default
+		);
 </script>
 
 <div class="bg-nuv-blue w-full h-[111px]" />
@@ -29,16 +27,13 @@
 	<div class="mt-[67px] px-[98px]">
 		<div class="flex flex-wrap">
 			{#each data.posts as post}
-				{#await getImages(post)}
-					<h1>Loading posts</h1>
-				{:then [mainImage, authorImage]}
+				{#await getImages(post) then authorImage}
 					<PostCard
 						slug={post.slug}
 						title={post.title}
 						date={post.date}
 						authorName={post.author}
 						{authorImage}
-						{mainImage}
 						topic={post.topic}
 						summary={post.summary}
 					/>


### PR DESCRIPTION
The `<img src= >` tag property is problematic in SvelteKit and was not needed as a decoration in the blog TOC list at "_/blog_".
An `<a href= >` to the page for each card is sufficient for SEO and gives a much less problematic template to render.
Avatar of the author is kept since it can be statically linked at build time

Please refer to [Vite static assets linking in dynamic import function](https://vitejs.dev/guide/assets.html)